### PR TITLE
Explicitly install colorspace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: r
 sudo: false
 cache: packages
 
+r_packages: colorspace
+
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: r
 sudo: false
 cache: packages
 
-r_packages: colorspace
+r_packages:
+  - colorspace
 
 addons:
   apt:


### PR DESCRIPTION
Explicitly installing the colorspace package makes the travis build work.

R CMD check produces a WARNING for the package due to outdated documentation however, which results in a failure (https://travis-ci.org/jimhester/dmisc2#L2182-L2189).
